### PR TITLE
Hookup emu-russia/dmgcpu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dmgcpu"]
+	path = dmgcpu
+	url = git@github.com:emurussia/dmgcpu.git

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,23 @@ $(DMG_CPU_B_CELLS) \
 $(DMG_CPU_B_PAGES)
 
 SM83 = \
+dmgcpu/HDL/sm83/_GekkioNames.v \
+dmgcpu/HDL/sm83/ALU.v \
+dmgcpu/HDL/sm83/Bottom.v \
+dmgcpu/HDL/sm83/DataMux.v \
+dmgcpu/HDL/sm83/Decoder1.v \
+dmgcpu/HDL/sm83/Decoder2.v \
+dmgcpu/HDL/sm83/Decoder3.v \
+dmgcpu/HDL/sm83/IDU.v \
+dmgcpu/HDL/sm83/IRNots.v \
+dmgcpu/HDL/sm83/IRQ.v \
+dmgcpu/HDL/sm83/Regs.v \
+dmgcpu/HDL/sm83/SeqCells.v \
+dmgcpu/HDL/sm83/Seq.v \
+dmgcpu/HDL/sm83/Thingy.v \
+dmgcpu/HDL/sm83/Top.v \
+
+#SM83 = \
 sm83/sm83.sv \
 sm83/sm83_adr_inc.sv \
 sm83/sm83_alu.sv \

--- a/dmg_cpu_b_gameboy.sv
+++ b/dmg_cpu_b_gameboy.sv
@@ -120,6 +120,59 @@ module dmg_cpu_b_gameboy;
 	logic [7:0]  cpu_d_out;
 	logic [15:0] cpu_a_out;
 
+	// See dmgcpu/ports.md
+	SM83Core cpu(
+		.M1(cpu_out_t1),         // out T1 
+		.CLK1(cpu_clkin_t2),     // in  T2 
+		.CLK2(cpu_clkin_t3),     // in  T3 
+		.CLK3(cpu_clkin_t4),     // in  T4 
+		.CLK4(cpu_clkin_t5),     // in  T5 
+		.CLK5(cpu_clkin_t6),     // in  T6 
+		.CLK6(cpu_clkin_t7),     // in  T7 
+		.CLK7(cpu_clkin_t8),     // in  T8 
+		.CLK8(cpu_clkin_t9),     // in  T9 
+		.CLK9(cpu_clkin_t10),    // in  T10
+		.CLK_ENA(cpu_clk_ena),   // out T11
+		.SYNC_RESET(cpu_in_t12), // in  T12
+		.RESET(cpu_in_t13),      // in  T13
+		.OSC_ENA(cpu_xo_ena),    // out T14
+		.OSC_STABLE(cpu_in_t15), // in  T15
+		// .in(cpu_in_t16),      // in  T16
+		.RD(cpu_raw_rd),         // out R1 
+		.WR(cpu_raw_wr),         // out R2 
+		.BUS_DISABLE(cpu_in_r3), // in  R3 
+		.MMIO_REQ(cpu_in_r4),    // in  R4 
+		.IPL_REQ(cpu_in_r5),     // in  R5 
+		.IPL_DISABLE(cpu_in_r6), // in  R6 
+		.MREQ(cpu_out_r7),       // out R7 
+
+		.CPU_IRQ_ACK({
+			cpu_irq7_ack, // out R28
+			cpu_irq6_ack, // out R26
+			cpu_irq5_ack, // out R24
+			cpu_irq4_ack, // out R22
+			cpu_irq3_ack, // out R20
+			cpu_irq2_ack, // out R18
+			cpu_irq1_ack, // out R16
+			cpu_irq0_ack  // out R14
+		}),
+
+		.CPU_IRQ_TRIG({
+			cpu_irq7_trig, // in  R29
+			cpu_irq6_trig, // in  R27
+			cpu_irq5_trig, // in  R25
+			cpu_irq4_trig, // in  R23
+			cpu_irq3_trig, // in  R21
+			cpu_irq2_trig, // in  R19
+			cpu_irq1_trig, // in  R17
+			cpu_irq0_trig  // in  R15
+		}),
+		.D(d),             // I/O B1-B8  
+		.A(cpu_a),         // out B9-B24 
+		.WAKE(cpu_wakeup), // in  B25 
+		.NMI(1'b0)
+	);
+
 	dmg_cpu_b dmg(.*, .t1('0), .t2('0), .vin(0.0), .unbonded_pad0('1), .unbonded_pad1());
 
 	task automatic xi_tick();
@@ -245,54 +298,15 @@ module dmg_cpu_b_gameboy;
 		end
 	end
 
-	sm83 cpu(.*);
-
 	assign ncyc        = !dmg.p1_clocks_reset.adyk && !dmg.p1_clocks_reset.alef;
-	assign cpu_a       = cpu_a_out;
-	assign d           = cpu_drv_d ? cpu_d_out : 'z;
 	assign din         = d;
-	assign cpu_out_r7  = (cpu_raw_rd || cpu_raw_wr) && !cpu_in_r4 && !cpu_in_r5;
 	assign clk_stable  = cpu_in_t15;
-	assign cpu_clk_ena = clk_ena;
 	assign reset       = cpu_in_t12;
 	assign areset      = cpu_in_t13;
-
-	initial cpu_a_out  = 0;
-	initial cpu_raw_rd = 0;
-	initial cpu_raw_wr = 0;
 
 	/* CPU must not drive data bus when cpu_clkin_t3 (BEDO) is low or cpu_clkin_t2 (BOWA) is high,
 	 * otherwise it collides with 0xff driven on the right side of page 5. */
 	assign cpu_drv_d = cpu_raw_wr && cpu_clkin_t3 && !cpu_clkin_t2;
-
-	always @(posedge cpu_clkin_t3) if (rd && !cpu_in_t12 && !cpu_in_t13) begin :read_cycle
-		cpu_a_out  <= adr;
-		cpu_raw_rd <= 1;
-		@(posedge cpu_clkin_t2);
-		cpu_raw_rd <= 0;
-		if (!cpu_in_r4 && !cpu_in_r5) /* Higher address byte is supposed to go low after external memory access */
-			cpu_a_out[15:8] <= 0;
-	end
-
-	always @(posedge cpu_clkin_t3) if (wr && !cpu_in_t12 && !cpu_in_t13) begin :write_cycle
-		cpu_a_out  <= adr;
-		cpu_d_out  <= '1;
-		cpu_raw_wr <= 1;
-		@(posedge cpu_clkin_t5);
-		cpu_d_out  <= dout;
-		@(posedge cpu_clkin_t2);
-		cpu_raw_wr <= 0;
-		if (!cpu_in_r4 && !cpu_in_r5) /* Higher address byte is supposed to go low after external memory access */
-			cpu_a_out[15:8] <= 0;
-	end
-
-	always @(posedge cpu_clkin_t10, posedge cpu_in_t12, posedge cpu_in_t13) if (cpu_in_t12 || cpu_in_t13) begin
-		disable read_cycle;
-		disable write_cycle;
-		cpu_raw_rd <= 0;
-		cpu_raw_wr <= 0;
-		cpu_a_out  <= 0;
-	end
 
 	assign irq[0] = cpu_irq0_trig;
 	assign irq[1] = cpu_irq1_trig;
@@ -302,17 +316,6 @@ module dmg_cpu_b_gameboy;
 	assign irq[5] = cpu_irq5_trig;
 	assign irq[6] = cpu_irq6_trig;
 	assign irq[7] = cpu_irq7_trig;
-
-	always_ff @(posedge clk) begin
-		cpu_irq0_ack <= iack[0];
-		cpu_irq1_ack <= iack[1];
-		cpu_irq2_ack <= iack[2];
-		cpu_irq3_ack <= iack[3];
-		cpu_irq4_ack <= iack[4];
-		cpu_irq5_ack <= iack[5];
-		cpu_irq6_ack <= iack[6];
-		cpu_irq7_ack <= iack[7];
-	end
 
 	program test;
 		int sample_idx;
@@ -369,9 +372,6 @@ module dmg_cpu_b_gameboy;
 			nrst = 0;
 
 			clk   = 0;
-
-			cpu_out_t1   = 0;
-			cpu_xo_ena   = 1;
 
 			cyc(64);
 			nrst = 1;


### PR DESCRIPTION
Hello! For some weeks now, I have been investigating if I could use the Verilog simulation in this repo to better understand the inner workings of the Game Boy and in some way improve the precision of my Game Boy emulator.

The main point that I want to investigate was the inner work of the PPU, and the precise read/write timing between the CPU and the PPU. But, as far as I know, you are using only an equivalent CPU implementation, not a reverse-engineered CPU from the Game Boy. This made me a little hesitant in learning its timing, knowing it may still be off.

But I discovered that there is a reverse-engineered HDL of the CPU core at https://github.com/emu-russia/dmgcpu, and I decided to try hooking it up with the simulation in this repo.

Connecting the two together went almost painless. But I could not get it to work; the CPU never starts running after the circuit RESET.

I tried investigating where things were going wrong, but I still could not figure it out (my investigation is resumed in `notes.txt`, copied in the section below), and I am not experienced in debugging Verilog. I could investigate a little more, but I presume there will be many more problems after fixing this one, so I became a little demotivated.

Regardless, I decided to publish my work here to not make it all go to waste.

---

# Investigation

The address bus of the CPU, when running in dmg-sim, never increments, whereas the simulation in dmgcpu does.

The signal `d` of the Sequencer never changes from 0x00..04000 to 0x00402..00, like the simulation in `dmgcpu` does.

The following inputs to the CPU differ from the simulation in dmgcpu:
 - slightly changed in the CLKs' phase during the reset, nothing major.
 - OSC_STABLE is always low, instead of high before the reset.
 - NMI is unconnected, instead of always 0
 - IPL_REQ is always high, instead of always 0
 - SYNC_RESET is always high, instead of going low after the reset.

`OSC_STABLE` becomes high when `UPOF` (last bit of `DIV`, 16Hz) is high, and `TUBO`, a latch for the `CLK_ENA` signal from the CPU, becomes low. In dmgcpu, `UPOF` is hardcoded to be high.

`OSC_STABLE = T1&~T2 | ~T1&T2 | UPOF&~TUBO`
`TUBO = nor_latch(.set(CLK_ENA), .reset(RESET | ~OSC_ENA))`

`OSC_STABLE` feeds the `SYNC_RESET` (CPU T12), which becomes locked low in `ASOL` latch. This made me think that `CLK_ENA` should only go high after `SYNC_RESET` is low.

Looking at Seq.v (see logic.py), `CLK_ENA` is low when `RESET` is high, or if the CPU halted:

RESET|SYNC_RESET| CLK_ENA
-----|----------|----------------------------------------
0    | 0        | `~(d[100] \| IR[4] & d[101]) \| SeqControl_1`
0    | 1        | `~(d[100] \| IR[4] & d[101])`
1    | x        | 0

From `_GekkioNames.v`:

- d[100]: s1_op_halt_s0xx
- d[101]: s1_op_nop_stop_s0xx

So `CLK_ENA` is almost unaffected by `SYNC_RESET`.

Another way to make `OSC_STABLE` go high is to ensure to only reset when `UPOF` is high. But `UPOF` does not run until `RESET` is low! And the CPU `RESET` is directly connected to the global simulation RESET!

Maybe `UPOF` should be reset high? Probably not, it may mess up with the `DIV` timing, and the simulation is too slow to make guessed changes.

`UPOF` is reset by `RESET_DIV`:
- `~RESET_DIV = ~(RESET | ~OSC_STABLE | (FF04_FF07 & CPU_WR & ~A1 & ~A2))`.
- `RESET_DIV = RESET | ~OSC_STABLE | <write to DIV>`

`ASOL` is reset by `RESET`.