### PR TITLE
Fix `sery = !rama`

### DIFF
--- a/dmg_cpu_b/pages/p33_sprite_pixel_shifter.sv
+++ b/dmg_cpu_b/pages/p33_sprite_pixel_shifter.sv
@@ -71,7 +71,7 @@ module sprite_pixel_shifter(
 	assign #T_INV  wyco = !suto;
 	assign #T_INV  selu = !rydu;
 	assign #T_INV  wamy = !sega;
-	assign #T_INV  sery = !sery;
+	assign #T_INV  sery = !rama;
 	assign #T_INV  sulu = !semo;
 	assign #T_NAND waxo = !(voby && tyta);
 	assign #T_NAND tyga = !(sele && tyta);


### PR DESCRIPTION
Found this out when trying to run the simulation with Verilator. This was causing it to never converge.