### PR TITLE
Fix mooneye's intr_2_mode3_timing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Results of Mooneye GB tests:
 | acceptance/ppu/intr\_2\_0\_timing              | PASS   |
 | acceptance/ppu/intr\_2\_mode0\_timing          | PASS   |
 | acceptance/ppu/intr\_2\_mode0\_timing\_sprites | PASS   |
-| acceptance/ppu/intr\_2\_mode3\_timing          | FAIL   |
+| acceptance/ppu/intr\_2\_mode3\_timing          | PASS   |
 | acceptance/ppu/intr\_2\_oam\_ok\_timing        | PASS   |
 | acceptance/ppu/lcdon\_timing-dmgABCmgbS        | FAIL   |
 | acceptance/ppu/lcdon\_write\_timing-GS         | FAIL   |

--- a/dmg_cpu_b/dmg_cpu_b.sv
+++ b/dmg_cpu_b/dmg_cpu_b.sv
@@ -884,8 +884,8 @@ module dmg_cpu_b(
 	assign reg_ff40[5]    = p23_video_regs.wymo;
 	assign reg_ff40[6]    = p23_video_regs.woky;
 	assign reg_ff40[7]    = p23_video_regs.xona;
-	assign reg_ff41[0]    = p21_video_control.sadu;
-	assign reg_ff41[1]    = p21_video_control.xaty;
+	assign reg_ff41[0]    = !p21_video_control.sadu;
+	assign reg_ff41[1]    = !p21_video_control.xaty;
 	assign reg_ff41[2]    = !p21_video_control.nrupo;
 	assign reg_ff41[3]    = p21_video_control.roxe;
 	assign reg_ff41[4]    = p21_video_control.rufo;

--- a/dmg_cpu_b/pages/p21_video_control.sv
+++ b/dmg_cpu_b/pages/p21_video_control.sv
@@ -116,14 +116,21 @@ module video_control(
 	assign #T_NOR  xaty = !(acyl || nxymu);
 	assign #T_INV  rypo = !semu;
 	assign #T_INV  ryju = !sepa;
-	assign #T_TRI  puzo = !vave ? !(!roxe) : 'z;
-	assign #T_TRI  sasy = !vave ? !(!refe) : 'z;
-	assign #T_TRI  pofo = !vave ? !(!rufo) : 'z;
-	assign #T_TRI  pote = !vave ? !(!rugu) : 'z;
-	assign #T_TRI  teby = tobe ? !sadu : 'z;
-	assign #T_TRI  wuga = tobe ? !xaty : 'z;
+
+	// FF41 (STAT) can change in the mid of a cycle and because the internal
+	// bus uses dynamic logic, this change is observable on the bus, where
+	// consecutive values are ANDed together. So in this specific case, we
+	// need to make sure to simulate the dynamic logic by only driving
+	// 0 values in the bus.
+	assign #T_TRI  puzo = !vave ? (!(!roxe) ? 1'bz : 1'b0) : 'z;
+	assign #T_TRI  sasy = !vave ? (!(!refe) ? 1'bz : 1'b0) : 'z;
+	assign #T_TRI  pofo = !vave ? (!(!rufo) ? 1'bz : 1'b0) : 'z;
+	assign #T_TRI  pote = !vave ? (!(!rugu) ? 1'bz : 1'b0) : 'z;
+	assign #T_TRI  teby = tobe ? (!sadu ? 1'bz : 1'b0) : 'z;
+	assign #T_TRI  wuga = tobe ? (!xaty ? 1'bz : 1'b0) : 'z;
 	assign #T_OR   pago = nreset9 || ryju;
-	assign #T_TRI  sego = tobe ? !nrupo : 'z;
+	assign #T_TRI  sego = tobe ? (!nrupo ? 1'bz : 1'b0) : 'z;
+
 	assign nnype = !nype;
 	assign int_vbl     = paru;
 	assign int_oam     = tapa;


### PR DESCRIPTION
While testing this project with `dmgcpu` hooked up, I noticed this failing. Later I found out that it also fails in the original project. Comparing the traces with ones I generated from my emulator that does pass the tests, I saw that the traces diverged when `dmg-sim` was reading the STAT register while it is changing. It was reading the final value of the STAT register, while the test expected that it read the previous value.

What was happening is that the bus (or the entire SoC?) uses dynamic-logic, so it only drives zeros in the bus. So when the values change while driving the bus, it is expected that they are AND'ed together.

I fixed that by changing the values that were driving the bus from `x` to `x ? z : 0`. I only did that for the FF41 register signals, but I suppose it would be better to do that for all signals that drive the bus? And for every trireg-like signal as well?

Here is the wave trace after the fix. Mid read the `ff41` signals changes from `a2` to `a3`, but the value in the buffer stays as `a2` as the test expects.

![image](https://github.com/user-attachments/assets/6c9d6563-8147-418a-9b9e-f10779189d8b)

I only checked these tests. I didn't check if this affected other tests, or investigate any other test to see if they need similar fixes.