### PR TITLE
Fix bit order of saved obj 6 x

### DIFF
--- a/dmg_cpu_b/dmg_cpu_b.sv
+++ b/dmg_cpu_b/dmg_cpu_b.sv
@@ -1117,9 +1117,9 @@ module dmg_cpu_b(
 	assign reg_obj6x[1] = !p31_sprite_x_matchers.yrac;
 	assign reg_obj6x[2] = !p31_sprite_x_matchers.ymem;
 	assign reg_obj6x[3] = !p31_sprite_x_matchers.yvag;
-	assign reg_obj6x[4] = !p31_sprite_x_matchers.zoly;
+	assign reg_obj6x[4] = !p31_sprite_x_matchers.zecu;
 	assign reg_obj6x[5] = !p31_sprite_x_matchers.zogo;
-	assign reg_obj6x[6] = !p31_sprite_x_matchers.zecu;
+	assign reg_obj6x[6] = !p31_sprite_x_matchers.zoly;
 	assign reg_obj6x[7] = !p31_sprite_x_matchers.zesa;
 	assign reg_obj4x[0] = !p31_sprite_x_matchers.wedu;
 	assign reg_obj4x[1] = !p31_sprite_x_matchers.ygaj;

--- a/dmg_cpu_b/pages/p31_sprite_x_matchers.sv
+++ b/dmg_cpu_b/pages/p31_sprite_x_matchers.sv
@@ -85,9 +85,9 @@ module sprite_x_matchers(
 	drlatch latch_duko(!asys, doku, zocy, duko);
 	drlatch latch_desu(!asys, doku, ypur, desu);
 	drlatch latch_dazo(!asys, doku, yvok, dazo);
-	drlatch latch_zoly(!zape, xaho, cose, zoly);
+	drlatch latch_zecu(!zape, xaho, cose, zecu);
 	drlatch latch_zogo(!zape, xaho, arop, zogo);
-	drlatch latch_zecu(!zape, xaho, xatu, zecu);
+	drlatch latch_zoly(!zape, xaho, xatu, zoly);
 	drlatch latch_zesa(!zape, xaho, bady, zesa);
 	drlatch latch_ycol(!zape, xaho, zago, ycol);
 	drlatch latch_yrac(!zape, xaho, zocy, yrac);


### PR DESCRIPTION
The X data for the sprite saved in the register 6 had the bit 6 and 4 swapped.

This caused the test `mooneye-teste-suite/acceptance/ppu/intr_2_mode0_timing_sprites.s` to fail due to wrong timing caused by the sprite X position being incorrect.

That test is marked as "PASS" in the README, but it was not passing in the current master. Not sure if it is a regression since the last time it was tested.